### PR TITLE
HKU CS Early Recruitment Scheme 已截止

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@
 
 # 香港大学
 
-【报名截止：2023.5.1】[HKU CS Early Recruitment Scheme for M.Phil. and Ph.D.](https://i.cs.hku.hk/~gradappl/index.html)
+~~【报名截止：2023.5.1】[HKU CS Early Recruitment Scheme for M.Phil. and Ph.D.](https://i.cs.hku.hk/~gradappl/index.html)~~
 
 # 香港中文大学（深圳）
 


### PR DESCRIPTION
香港大学的HKU CS Early Recruitment Scheme for M.Phil. and Ph.D.项目已过截止日期 2023.05.01