### PR TITLE
国防科技大学计算机夏令营申请截止

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@
 
 # 国防科技大学
 
-【报名截止：N/A】[计算机学院](http://yjszs.nudt.edu.cn/pubweb/homePageList/detailed.view?keyId=13072)
+~~【报名截止：2023.6.30】[计算机学院](http://yjszs.nudt.edu.cn/pubweb/homePageList/detailed.view?keyId=13072)~~
 
 # 重庆大学
 


### PR DESCRIPTION
根据群文件《2023计算机学院夏令营组织方案》，材料邮寄已于2023年6月30日截止。